### PR TITLE
refactor(hosts/kiwi): Create a backup module to unify backups between services

### DIFF
--- a/hosts/kiwi/backups.nix
+++ b/hosts/kiwi/backups.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  vars,
+  lib,
+  ...
+}:
+with lib;
+
+let
+  cfg = config.kiwi.backups;
+in
+{
+  options.kiwi.backups = mkOption {
+    type = types.attrsOf (
+      types.submodule (
+        { config, name, ... }:
+        {
+          options = {
+            paths = mkOption {
+              type = types.nullOr (types.listOf types.str);
+              default = [ ];
+            };
+            backupPrepareCommand = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+            };
+            backupCleanupCommand = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+            };
+          };
+        }
+      )
+    );
+  };
+  config = {
+    sops.secrets."backups/restic/repositoryPass".owner = "root";
+    sops.secrets."backups/restic/sshKey".owner = "root";
+    services.restic.backups = mapAttrs' (
+      name: conf:
+      nameValuePair name {
+        user = "root";
+        backupPrepareCommand = conf.backupPrepareCommand;
+        paths = conf.paths;
+        initialize = true;
+        repository = "sftp:${
+          vars.sensitive.backups.user + "@" + vars.sensitive.backups.host
+        }:restic-repo-${name}";
+        extraOptions = [
+          "sftp.command='ssh ${vars.sensitive.backups.user + "@" + vars.sensitive.backups.host} -p 23 -i ${
+            config.sops.secrets."backups/restic/sshKey".path
+          } -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -s sftp'"
+        ];
+        passwordFile = config.sops.secrets."backups/restic/repositoryPass".path;
+        pruneOpts = [
+          "--keep-daily 7"
+          "--keep-weekly 8"
+          "--keep-monthly 12"
+          "--keep-yearly 100"
+        ];
+        timerConfig = {
+          OnCalendar = "daily";
+          RandomizedDelaySec = "6h";
+          Persistent = true;
+        };
+      }
+    ) cfg;
+  };
+}

--- a/hosts/kiwi/default.nix
+++ b/hosts/kiwi/default.nix
@@ -7,6 +7,7 @@
 {
   imports = [
     ./hardware.nix
+    ./backups.nix
 
     ./services/nginx.nix
     ./services/ocis.nix

--- a/hosts/kiwi/secrets.yaml
+++ b/hosts/kiwi/secrets.yaml
@@ -1,17 +1,7 @@
 backups:
     restic:
-        vaultwarden:
-            repositoryPass: ENC[AES256_GCM,data:NenzCYhNTIMAQkmVVx/Tv2RmysMflERF,iv:IpM/OErxHEMG/zVSGkvjRpC9ErB0EG9JfaB4YqBS5Is=,tag:HGx8nfH8sNUMLEJHBw6SBQ==,type:str]
-            sshKey: ENC[AES256_GCM,data:R6E5iMNckbKHbQvPkllEtVqREehN3muo36QbXyZnHtfSqlT6Z0Z6JF8KNe80lQQB7B23RG50R1h6MXPH45vNUuNFWSHnbZlRS7JOBZ2BNT/axjHA10SoGEmkCGtxkfP6zcvzob2tNUzCzDwB860s687tUxgw9LgZ3IlZyq9JF5ee5XDn5MF7JhiMpp6kSTvI0SmieXyEwf8t7uplZjZk7eAU4pdz+PG7xclwCHJYCwoLsK+g6aDbiojrHQsEJ4QklE3HG0Wle5/IhmmaWW5MY5zB9cVJJfogUorYaDpyWkWxh3PgreKvkagA26kCyNQrbwIii+ocaz0R9zOS07ZmkkShJKa0GeHC+XxawbS2KXqtdtJCz9o0ekZhrCXXOr6sgpgDsXnOB2j1YcEg/x71sUzuJbjKrJIH/jAdLfZhB2CYpkBYOxu2IIzQ5BsgPj0+JmVl+d/77BPinpz7KAU1MoP0idasecTGa1LONX1+gFl2K7cPjFB1m/TrH9vK3Az7p1IP63S5N7PNOleCigtT,iv:yShlSJ1J5gErCBf/zsWWRmP7v1lF7zVfWM697rwlVaY=,tag:gycNsEBT9rtZHiYF0dF3kA==,type:str]
-        immich:
-            repositoryPass: ENC[AES256_GCM,data:hmNDmWgkMomd3G4oEvmMV4Fl711mXft+,iv:V45Q/42iblG3OXGkIbKczi6hVoZ9bQQkfRKFv+hBg0c=,tag:Uo4lBx8Rd72ukjFXQyDtgQ==,type:str]
-            sshKey: ENC[AES256_GCM,data:koyaypQPFMYp3R1iyGJOkzoDgCaJLjfV4C7UKoOYWuvvpXO0LyfazrUmt3ZBvHlIhuiBIx9mYS4hf3C9OF0tXgaYJ0CAENDn+5Bp+VlAw7NFxc6YibG6cWifI9h+97RkCeWgEwqahoZj4IC9Ch37LZwbyJ3332TByLrEyDy1VsWTNqZR4C8X8m9vXP3lhIoevZdq7qSkrEkBzBgJ6bG9NI78USJF1Krrj7ZoPDOO6kRd//sposeMIdEQWIOdEDzBrT111iY2sQqrIY2DC8m1zPPM5nLEtH4hdPqctx9rOZoEyvTf2jifMQLb9ha2pkmecrD3mZ3q9XIewkE6NFjNnf3TJhqj4H2NuLNfMTfkc+j12Hi3TWlCYr8HrgR2LNn63KW2ZcKQ78dnbW0YbpfJ2y3m7+w8pxd+a6ReYlnllc+4DVoLaK+FxojxcE7ZMjoTe0z33HgIlNecDXW6YXo9BSo+Qscl3UBtX0RfZwZ00oipMQ7uH+9An/zFtZzCTgvM2kBr9F+69TNxOA13ZMT5,iv:pFsos9McCynHNtPUk/tHCOosH9eMaF1kpUR3dJz2tMo=,tag:mw3MQqeMP3mfn0UQdOR6jA==,type:str]
-        ocis:
-            repositoryPass: ENC[AES256_GCM,data:PT2MqAUa+wsQy5s4d7GPM9UQJzYrQ33m,iv:jOHGzCZNJ/r4aINOQ+ZVscaRZMj+qi9NX++rdVqjBIk=,tag:Z5ije4f6b7lJXnWDzcwM0w==,type:str]
-            sshKey: ENC[AES256_GCM,data:MYLs4Zz1SYFOztOrzX17igcEyPPwI5cjj3OZUc0uX/0RjBiByvoCU+/v3m3CgLEJ8uapfqyXGbrdlybowtclkrAsVe/RDxEohDKoDJm534rYcqeg4xvTA+XlmKe6UsxZVmN6ZF3hLh9t93TIkQ5Bv1uxtwJ9NRry4FILGmTa1YYacCkvKHsxx5fMSBJIbp6NkW7ZFvDlbMx4y2HlJqWYvOQbDqTp3JjwtAbi/8/ok9pTgUFWPLWZk0bXxX79MnKBUFR3AYnlY09uqSeqxfTHWbWqt3Jwmgl7/98HPsHxpIiNKWUi9QanMVib0JZeVmXqnuw1RCwZ1LYoAeq9tl22c0cx6KP3BP3Wlx4qIixHhMRSquMRCJmFdbOKl6o9fXKjx9MiuUw0mfzAFeQhCgXdPrDOdzMqBlc3HY2kzEv0uPwV5XcwsmbfTbqdFGBSxurS56zIkDK5Xp3kRJIIcYaZL5+3CjPytu/YSGc+FUrSSXoXvw9Wk/9TCKzoAPkHv2kuvBXNuV2HF8hXvdbleUKe,iv:kM58o7h7BvYf1t1X65nCYUYs20v8XZ+Sw2Wy9mojW1w=,tag:P4IRQTizDd9mQ3ON+QwHFA==,type:str]
-        keycloak:
-            repositoryPass: ENC[AES256_GCM,data:ZC+feLW2x2LGj1a+Dzgz0mnNQlhqZXHA,iv:HY8k8ZeUS7KAWcoHNMlqRBcRWMLH8aw1FQET18xW4o8=,tag:XADW4nXKieQDVvefNLc1vA==,type:str]
-            sshKey: ENC[AES256_GCM,data:eGpl+zFuVhMtgd8887HEeUAh3OXOj76aVPogeBSTD5vapdcVwQqADtpT8fH9b+G83eWl0kKbBwDFzWL7uDq7jEWLC+Fk1QKfAPFpIFO03YGYjPoPe4YfDvZ/6XnnalsMqM2R8IMQeAHxD7bsBQ8TzI2eD03J/sKFee0afbTo85N3xKqwFvdMJnf6Uik5ESRR7dHXeHCRd8T7GCdZ3W/fbYa2T1Rag/ZgTNwTA+u3A7/vQjQqJaYQDV9YGxpnhSGj1N7H7h9ycNfn8Z90JLkL8g/f9Hg9xycW2MCTDDoBs4K8Y4pqOrhuOPKzadGGq3IkKK3ZcyJt4Lhl0R7O7qzRDDoQ8Vg0P+OKI1nvbTZmx8GSZ9VOyZpejCrSpW/btmAxDMQ1aeaMVynu60GlymwFGZcmSGKsx1WDHXai5RRvTg+Nl7VY5kK0eAyb0SjQCpxH7N4dt+BbFgL7QvB3tvUWJ9nRQfMgYlewlbMOZfHcYgsqBbhArOvFi686ZHedUSn59WXPExbc2D0G+PQ3TOAI,iv:pfxenq4xtNQ0HLsjhFKvcjdUTj/NBKxt3F4Ouk71Ojg=,tag:iTo3NK4G+N/ZxTYLAV7qEw==,type:str]
+        repositoryPass: ENC[AES256_GCM,data:oHzUY9vcjxgEmdGrKNUIDo5DRnrq65lI,iv:sXDj2Qvdu9e/NTKn41GY6U5nM+LfmKrvg+Z3z45V/mI=,tag:URnrUr/Gcw4lvO8w0Au72g==,type:str]
+        sshKey: ENC[AES256_GCM,data:A2VuMRBiZ0MYns+f2h+s9CY2iaWjJ/VTJhHcI2o+blrAl0rFuZDXQm/hOKkOyuQW2Nd8qo2yzGQrZazK9F5VqejQ4qtmeBn/dIO5HdSg3Jdox/gnN8Q58GvdKq07KKqcBImLGlsDbAvd2K3w5Ply3ssMzkly+iJgVOEBRzIVGTQhyFzBmdtfYeyzD3LZvUJ9wKpG8kcbDxzIPboeDiUMjXJ3QuCa9TFi/fhTnNNIsgiATZEeOJWx25o9zDRbtdGN5ZwX2BMTcoRdWnKeolVMxPAioavDY9vLcDWb7iaEpXyW0UNc7/UXmzj+q/629qRCB281TND0eIa7A4bUZOT3/wnvhqjIjhiJ04JhXL7MBzvrrTl2zbu4rCyN1RtVbJvcQ4eIXwEp6Mack4jBqPaQQcDTKLToZ4Jd7QsePICh/xrSWih174GzOIaSNoVYoJ4AmjeGp1t6khKcJPVHVEPu427ON4HiUghzzlLA6YhT0BQAgo+UD0xNieU9JyDRoNLDIGuoDdG+M+Tmu9ByXcJ/,iv:imCo+ySluw19m3diY+8kZ33vXFxJXPRQwJyyL4g+FPk=,tag:4RIUoaXc0wiMWt/U+kAxaw==,type:str]
 system:
     smb:
         glouton:
@@ -54,8 +44,8 @@ sops:
             L24yTWNtUHJwY2lUZ254VTIrdW5JUkEKvvDc1oZzIx2K/3hrw072xL+1Z0rK/uoV
             hZ+fW+8z6juunPwX54R7NLvDJdhZspsr8CBzQw5rwul45XKBo+sUWA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-04-08T13:50:06Z"
-    mac: ENC[AES256_GCM,data:gd8Q8S98jEIvQnn+bWAIHqm/3LQtiqvxKmiRiH3c+2nk38RCg5NUcRSmY/gC0OHpqSkQMXBQYuumbqJ0Jn767r24l7CdXCK25QRztzKA8CCsRsUGo2VHazPfhvfdhGTaAG6l3np38ig+pd9qt2DA4CMWLbT0JstYznKpIh2zRSo=,iv:2Mt0IWg7WzNdGbcydI4iLo3Bh9HlH2czLkpgraSdTUA=,tag:zZkBGOS7c65bqMwwO4d7Jg==,type:str]
+    lastmodified: "2024-04-08T14:59:15Z"
+    mac: ENC[AES256_GCM,data:ilU1g6ccslRQWSGvhtMXTTJX8iatZR3vWG7yQZ46fKTWDLkt6SmFfXD4hHlbBEGN2y9JaraflB/0RcSHv7hgWO4Oqp5l6bK5Q0h3Jv2Gm5ssP3rksVZjjbJZ3A9y0H9krd+xyG7bq0+XU5Nv/Y6z6DrxYZFnC/wQMbzovQggztc=,iv:XKdWLn0wwz+pYCyP6pWPVa10Q5HjJOSNOjvDxiSEAEs=,tag:wvQv1Jd1/J4+6eOm12Vw+w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/hosts/kiwi/services/keycloak.nix
+++ b/hosts/kiwi/services/keycloak.nix
@@ -38,9 +38,8 @@
     };
   };
 
-  sops.secrets."backups/restic/keycloak/repositoryPass" = { };
-  sops.secrets."backups/restic/keycloak/sshKey" = { };
-  services.restic.backups.keycloak = {
+  kiwi.backups.keycloak = {
+    paths = [ vars.services.keycloak.backups.tmpDir ];
     backupPrepareCommand = ''
       ${pkgs.bash}/bin/bash -c '
         if ! mkdir -p "${vars.services.keycloak.backups.tmpDir}"; then
@@ -54,30 +53,8 @@
            --stream=xbstream | ${pkgs.gzip}/bin/gzip > "${vars.services.keycloak.backups.tmpDir}/keycloak-db-dump.sql.gz"
       '
     '';
-    paths = [ vars.services.keycloak.backups.tmpDir ];
-    repository = "sftp:${
-      vars.sensitive.backups.user + "@" + vars.sensitive.backups.host
-    }:restic-repo-keycloak";
-    extraOptions = [
-      "sftp.command='ssh ${vars.sensitive.backups.user + "@" + vars.sensitive.backups.host} -p 23 -i ${
-        config.sops.secrets."backups/restic/keycloak/sshKey".path
-      } -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -s sftp'"
-    ];
-    initialize = true;
-    passwordFile = config.sops.secrets."backups/restic/keycloak/repositoryPass".path;
     backupCleanupCommand = ''
       ${pkgs.bash}/bin/bash -c 'rm -rf "${vars.services.keycloak.backups.tmpDir}"'
     '';
-    pruneOpts = [
-      "--keep-daily 7"
-      "--keep-weekly 8"
-      "--keep-monthly 12"
-      "--keep-yearly 100"
-    ];
-    timerConfig = {
-      OnCalendar = "daily";
-      RandomizedDelaySec = "6h";
-      Persistent = true;
-    };
   };
 }

--- a/hosts/kiwi/services/ocis.nix
+++ b/hosts/kiwi/services/ocis.nix
@@ -61,31 +61,7 @@
     };
   };
 
-  sops.secrets."backups/restic/ocis/repositoryPass".owner = config.users.users.colon.name;
-  sops.secrets."backups/restic/ocis/sshKey".owner = config.users.users.colon.name;
-  services.restic.backups.ocis = {
-    user = "colon";
+  kiwi.backups.ocis = {
     paths = [ vars.services.ocis.dataDir ];
-    repository = "sftp:${
-      vars.sensitive.backups.user + "@" + vars.sensitive.backups.host
-    }:restic-repo-ocis";
-    extraOptions = [
-      "sftp.command='ssh ${vars.sensitive.backups.user + "@" + vars.sensitive.backups.host} -p 23 -i ${
-        config.sops.secrets."backups/restic/ocis/sshKey".path
-      } -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -s sftp'"
-    ];
-    initialize = true;
-    passwordFile = config.sops.secrets."backups/restic/ocis/repositoryPass".path;
-    pruneOpts = [
-      "--keep-daily 7"
-      "--keep-weekly 8"
-      "--keep-monthly 12"
-      "--keep-yearly 100"
-    ];
-    timerConfig = {
-      OnCalendar = "daily";
-      RandomizedDelaySec = "6h";
-      Persistent = true;
-    };
   };
 }


### PR DESCRIPTION
The purpose of this pull request is to unify backup declaration between services in order to have a simplified view over the backup process.
I had to create a backup module which declares the default configuration and 'overlays' services.restic.backups, enabling multiple instances of this service.
Without prior experience on modules, I'm aware this pull request may have some defects. I will need to keep an eye on this